### PR TITLE
Update _llama_cpp.py

### DIFF
--- a/guidance/llms/_llama_cpp.py
+++ b/guidance/llms/_llama_cpp.py
@@ -283,7 +283,7 @@ class LlamaCppSession(LLMSession):
             token_healing = self.llm.token_healing
 
         # generate the cache key
-        key = self._cache_key(locals())
+        key = self._gen_key(locals())
 
         # set the stop patterns
         if stop is not None:


### PR DESCRIPTION
Fixing small method call error i ran into when running your combined guidance + llama_cpp implementation.

I believe LlamaCppSession class inherits from the LLMSession class which has methods `_cache_params` and `_gen_key`, but I see no `_cache_key`.

Thank you for your constant work in the local LLM community, you are a godsend, I am sure I speak for many more when I send my appreciation!